### PR TITLE
fix(documentation.vscode.md): fix slashes and itemized list

### DIFF
--- a/documentation/vscode.md
+++ b/documentation/vscode.md
@@ -12,6 +12,7 @@ ads: false
 ---
 
 If you have installed [Visual Studio Code](https://code.visualstudio.com/), you can easily add the Lean extension by clicking the extension icon in the view bar at left and searching for `lean`. To run properly, the extension needs to be able to find Lean. You can make this possible in one of three ways:
+
 - Add a path to the Lean binary to your `PATH` environment variable.
 - Use `make install` from the Lean build directory to copy the Lean binary to a directory in your search path.
 - Specify the Lean path to VS Code in the `settings.json` file, by choosing `File -> Preferences -> User Settings`.
@@ -23,7 +24,7 @@ With the third option, you should add the lines
 {% endhighlight %}
 for a Windows installation, or
 {% highlight bash %}
-  "lean.executablePath": "[path-to-lean]\bin\lean",
+  "lean.executablePath": "[path-to-lean]/bin/lean",
   "input-assist.languages": ["lean"]
 {% endhighlight %}
 for Linux or macOS.

--- a/documentation/vscode.md
+++ b/documentation/vscode.md
@@ -15,19 +15,7 @@ If you have installed [Visual Studio Code](https://code.visualstudio.com/), you 
 
 - Add a path to the Lean binary to your `PATH` environment variable.
 - Use `make install` from the Lean build directory to copy the Lean binary to a directory in your search path.
-- Specify the Lean path to VS Code in the `settings.json` file, by choosing `File -> Preferences -> User Settings`.
-
-With the third option, you should add the lines
-{% highlight bash %}
-  "lean.executablePath": "[path-to-lean]\\bin\\lean.exe",
-  "input-assist.languages": ["lean"]
-{% endhighlight %}
-for a Windows installation, or
-{% highlight bash %}
-  "lean.executablePath": "[path-to-lean]/bin/lean",
-  "input-assist.languages": ["lean"]
-{% endhighlight %}
-for Linux or macOS.
+- Specify the Lean path in the VS Code `settings.json` file. To do this, choose `File -> Preferences -> User Settings`, find `Lean configuration`, and set `lean.executablePath` to the correct path.
 
 After that, if you create a file with the extension `.lean` and edit it, Lean will check the file continuously as you type. For example, if you type the words `check id`, the word `check` is underlined in green to indicate a response from the Lean server. Hovering over the word `check` displays the response, in this case, the type of the identity function.
 

--- a/publications/index.md
+++ b/publications/index.md
@@ -52,8 +52,6 @@ ads: false
 
 - [The Lean Theorem Prover](http://leanprover.github.io/presentations/20150218_MSR), PL(X) meeting at <a href="http://research.microsoft.com/en-us/groups/rise/">Microsoft Research</a>, February 2015
 
-- [Lean mode for Emacs](http://leanprover.github.io/presentations/20150123_lean-mode/lean-mode.pdf)
-
 ## Formalizations
 
 - "Constructing the Propositional Truncation using Non-recursive HITs".


### PR DESCRIPTION
I am not sure adding a blank line will fix the itemized list, since I don't see the problem either way when I test the site locally. But we have a similar list in `documentation/index.md`, so it should worik.