### PR TITLE
fix(index.md): Lean 3 is frozen

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -57,7 +57,7 @@ The next two are incomplete and outdated but may be helpful:
   [pdf](../reference/lean_reference.pdf)
 
 The current version of Lean is Lean 3, its development is frozen. The source code and libraries can be found on
-[github](http://github.com/leanprover/lean). The next version of Lean will be released when it will be ready.
+[github](http://github.com/leanprover/lean). The next version of Lean will be released when it is ready.
 
 ## Lean 2
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -56,9 +56,8 @@ The next two are incomplete and outdated but may be helpful:
   [online version](../reference),
   [pdf](../reference/lean_reference.pdf)
 
-The current version of Lean is Lean 3, and is under active
-development. The source code and libraries can be found on
-[github](http://github.com/leanprover/lean).
+The current version of Lean is Lean 3, its development is frozen. The source code and libraries can be found on
+[github](http://github.com/leanprover/lean). The next version of Lean will be released when it will be ready.
 
 ## Lean 2
 


### PR DESCRIPTION
This is a minimal fix to correct a misleading statement. But I'm not sure why that sentence is there instead of being near the beginning (after the link to the FAQ probably).