### PR TITLE
docs: Fix links to `Skinny Bones` Jekyll template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Based on http://mmistakes.github.io/skinny-bones-jekyll/
+Based on https://mmistakes.github.io/jekyll-theme-skinny-bones/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,7 +11,7 @@
 		{% endfor %}
 		</ul>
 	</nav><!-- /.bottom-menu -->
-	<p class="copyright">&#169; {{ site.time | date: '%Y' }} <a href="{{ site.url }}">{{ site.title }}</a> powered by <a href="http://jekyllrb.com">Jekyll</a> + <a href="http://mmistakes.github.io/skinny-bones-jekyll/">Skinny Bones</a>.</p>
+	<p class="copyright">&#169; {{ site.time | date: '%Y' }} <a href="{{ site.url }}">{{ site.title }}</a> powered by <a href="http://jekyllrb.com">Jekyll</a> + <a href="https://mmistakes.github.io/jekyll-theme-skinny-bones/">Skinny Bones</a>.</p>
 </footer>
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
# Summary

This PR updates the link to the Jekyll template `Skinny Bones`, which is currently incorrect as it is.