### PR TITLE
refocus links to community

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -22,7 +22,6 @@ Research in 2013. It is an open source project, hosted on
 [GitHub](https://github.com/leanprover). [Lean 3](https://github.com/leanprover/lean)
 is the latest official release. Development has shifted to [Lean 4](https://github.com/leanprover/lean4),
 which is not ready for general use yet. Meanwhile, members of the Lean community centered
-around the mathematical components library [mathlib](https://github.com/leanprover-community/mathlib)
-have continued maintenance and development of Lean 3 as a separate [community version](https://github.com/leanprover-community/lean).
+around the mathematical components library mathlib have continued maintenance and development of Lean 3 as a separate community version.
 Further information about mathlib and the Lean 3 community releases can be found at the [Lean Community](https://leanprover-community.github.io/index.html)
 website, including an online version of Lean.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -13,7 +13,8 @@ ads: false
 
 You can experiment with Lean by running an
 [online](https://leanprover.github.io/live/) Javascript version in
-your browser. If you have installed Lean locally, you can use it
+your browser (see also the [community version](https://leanprover-community.github.io/lean-web-editor/)).
+If you have installed Lean locally, you can use it
 interactively with [Visual Studio Code](https://code.visualstudio.com/) or
 [Emacs](http://www.gnu.org/software/emacs/). See the
 [Using Lean](https://leanprover.github.io/reference/using_lean.html)
@@ -26,13 +27,8 @@ cannot accommodate feature requests at this stage. If you are trying to decide
 whether to invest time in learning to use Lean right now, this
 [FAQ](https://github.com/leanprover/lean/blob/master/doc/faq.md) may be helpful.
 
-The following tutorial is available in an online version that
-runs alongside a Lean in your browser, and as a PDF document.
-
-- *Theorem Proving in Lean*<br />
-  A introduction to using Lean as an interactive theorem prover. <br />
-  [online tutorial](../theorem_proving_in_lean),
-  [pdf](../theorem_proving_in_lean/theorem_proving_in_lean.pdf)<br />
+The [learning resources page](https://leanprover-community.github.io/learn.html) 
+of the community website lists many tutorials and documentation sources.
 
 ## Chat Room
 

--- a/download/index.md
+++ b/download/index.md
@@ -17,7 +17,7 @@ Lean 4 is under development. There are no official releases yet.
 
 # Lean 3
 
-These are the official releases of Lean 3. For the extended community version of Lean 3, please see [leanprover-community/lean](https://github.com/leanprover-community/lean/).
+Below are the frozen official releases of Lean 3. For the extended community version of Lean 3, please see the [community website](https://leanprover-community.github.io/).
 
 ## Binary
 

--- a/download/index.md
+++ b/download/index.md
@@ -17,7 +17,7 @@ Lean 4 is under development. There are no official releases yet.
 
 # Lean 3
 
-Below are the frozen official releases of Lean 3. For the extended community version of Lean 3, please see the [community website](https://leanprover-community.github.io/).
+Below are the official releases of Lean 3. For the extended community version of Lean 3, please see the [community website](https://leanprover-community.github.io/).
 
 ## Binary
 


### PR DESCRIPTION
The proposed changes mostly remove some specific links to community projects in order to channel all community access through the [main website](https://leanprover-community.github.io/).