### PR TITLE
Fix nav links on mobile

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -10,7 +10,7 @@
                 @include transform(translate(-1600px,0));
         }
         .inner-wrap {
-                height:100px;
+                min-height:100px;
                 @include outer-container;
         }
 }


### PR DESCRIPTION
On mobile, the screen is smaller so the links in the header wrap around. This causes the nav to be much taller than 100px, but since the height is hardcoded at 100px, this causes the lower nav links on the screen to be visible but not clickable as they are covered up by the main page div. This PR changes `height` to `min-height` so that when the height of the nav grows due to text wrapping on mobile, everything still works as expected and the height of the nav can grow to accommodate the links.

<img width="375" alt="Screen Shot 2022-10-27 at 11 16 17" src="https://user-images.githubusercontent.com/200725/198259540-8b1891a3-b5b7-4d99-aa4f-666f291adc55.png">
