### PR TITLE
replace old Lean Together links with link to community page

### DIFF
--- a/links/index.md
+++ b/links/index.md
@@ -79,10 +79,6 @@ ads: false
 
 - [OpenAI formal math](https://openai.com/blog/formal-math/)
 
-## Lean Together meetings
+## Lean meetings
 
-- [2021](https://leanprover-community.github.io/lt2021/)
-
-- [2020](https://www.andrew.cmu.edu/user/avigad/meetings/fomm2020/)
-
-- [2019](https://lean-forward.github.io/lean-together/2019/)
+The community website hosts a list of [upcoming and past events](https://leanprover-community.github.io/events.html) on Lean.


### PR DESCRIPTION
A list of events from 2019, 2020, and 2021 is beginning to look a bit sad. I think it's better to replace this section with a link to the extremely full [calendar](https://leanprover-community.github.io/events.html) maintained on the community website.

Alternatively I'm happy to "backport" from that page, or even automate if appropriate.