### PR TITLE
partially revert: Un-domain self-links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ logo: lean_logo.svg
 teaser:
 locale:
 baseurl:
-url:
+url: https://lean-lang.org
 safe: true
 
 # Jekyll configuration


### PR DESCRIPTION
It is likely that ac5bfcfef79b9a395b8eadb24473eb213f4cd9eb may have accidentally ruined some links.

At least the following two pages are currently 404ing:
- https://lean-lang.org/theorem_proving_in_lean4/title_page.html
- https://lean-lang.org/functional_programming_in_lean/